### PR TITLE
加入 mips64el 编译支持

### DIFF
--- a/SPECS.p/pstoedit/pstoedit.spec
+++ b/SPECS.p/pstoedit/pstoedit.spec
@@ -14,7 +14,7 @@ BuildRequires:  libpng-devel
 BuildRequires:  dos2unix
 BuildRequires:  ghostscript
 BuildRequires:  plotutils-devel
-%ifnarch ia64
+%ifnarch ia64 mips64el
 BuildRequires:  libEMF-devel
 %endif
 


### PR DESCRIPTION
libEMF 不支持 mips64el ，去掉依赖。
