### PR TITLE
加入 mips64el 编译支持

### DIFF
--- a/SPECS.m/microcode_ctl/microcode_ctl.spec
+++ b/SPECS.m/microcode_ctl/microcode_ctl.spec
@@ -10,7 +10,7 @@ License:        GPLv2+ and Redistributable, no modification permitted
 URL:            http://fedorahosted.org/microcode_ctl
 Source0:        http://fedorahosted.org/released/microcode_ctl/%{name}-%{upstream_version}.tar.xz
 Buildroot:      %{_tmppath}/%{name}-%{version}-root
-ExclusiveArch:  %{ix86} x86_64
+ExclusiveArch:  %{ix86} x86_64 mips64el
 
 %description
 The microcode_ctl utility is a companion to the microcode driver written


### PR DESCRIPTION
microcode_ctl 可以成功编译，添加支持。以防万一用吧，多个软件功能总还是好的。
