### PR TITLE
修复编译错误

### DIFF
--- a/SPECS.g/gd/gd.spec
+++ b/SPECS.g/gd/gd.spec
@@ -114,8 +114,8 @@ CFLAGS="$RPM_OPT_FLAGS -DDEFAULT_FONTPATH='\"\
 /usr/share/fonts/liberation\"'"
 
 %configure \
-    --with-vpx=%{_prefix} \
-    --with-tiff=%{_prefix} \
+    --with-vpx \
+    --with-tiff \
     --disable-rpath
 make %{?_smp_mflags}
 


### PR DESCRIPTION
gd：
mips64el 如果在 mutillib 下面，直接指定 vpx 和 tiff 的 prefix 目标地址，会直接将 LIB 目录设置为 /usr/lib ，这会导致 gcc 的编译参数中出现 -L/usr/lib 。这个参数会导致 gcc 优先调用 32 位的函数库，导致 ABI 错误无法继续编译。amd64 应该也有这个问题，估计是 amd64 编译时没有装 32 位库，所以没有报错。
