### PR TITLE
修复编译错误

### DIFF
--- a/SPECS.l/lirc/lirc.spec
+++ b/SPECS.l/lirc/lirc.spec
@@ -224,7 +224,6 @@ done
 %build
 mkdir m4 || :
 autoreconf -fi
-export CFLAGS="%{optflags} -Werror=format-security"
 %configure \
   --libdir=%{_libdir} \
   --disable-static \


### PR DESCRIPTION
lirc：
增加的 CFLAGS 参数反而导致 configure 无法继续。估计是 gcc 改变了默认参数导致冲突了。
