### PR TITLE
修复编译错误

### DIFF
--- a/SPECS.o/openjpeg/openjpeg.spec
+++ b/SPECS.o/openjpeg/openjpeg.spec
@@ -181,7 +181,7 @@ rm -rf %{buildroot}
 %endif
 # legacy/compat header locations
 %{_includedir}/openjpeg.h
-%{_includedir}/openjpeg/
+%{_includedir}/openjpeg
 
 
 %changelog

--- a/SPECS.o/ots/ots-0.5.0-remove_double_en.xml.patch
+++ b/SPECS.o/ots/ots-0.5.0-remove_double_en.xml.patch
@@ -1,0 +1,12 @@
+diff -Nuri ots-0.5.0-orig/dic/Makefile.am ots-0.5.0/dic/Makefile.am
+--- ots-0.5.0-orig/dic/Makefile.am	2015-01-09 15:20:13.189749928 +0800
++++ ots-0.5.0/dic/Makefile.am	2015-01-09 15:20:35.323550323 +0800
+@@ -1,7 +1,7 @@
+ DICTS=bg.xml ca.xml cs.xml cy.xml da.xml de.xml el.xml en.xml eo.xml es.xml \
+       et.xml eu.xml fi.xml fr.xml ga.xml gl.xml he.xml hu.xml ia.xml id.xml \
+       is.xml it.xml lv.xml mi.xml ms.xml mt.xml nl.xml nn.xml pl.xml pt.xml \
+-      ro.xml ru.xml sv.xml tl.xml tr.xml uk.xml yi.xml en.xml
++      ro.xml ru.xml sv.xml tl.xml tr.xml uk.xml yi.xml
+ 
+ pkgdata_DATA = $(DICTS)
+ 

--- a/SPECS.o/ots/ots.spec
+++ b/SPECS.o/ots/ots.spec
@@ -10,6 +10,8 @@ Group:		System Environment/Libraries
 Group(zh_CN.UTF-8):	系统环境/库
 
 Source0:	http://prdownloads.sourceforge.net/libots/ots-%{version}.tar.gz
+Patch0:  ots-0.5.0-remove_double_en.xml.patch
+
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
@@ -60,6 +62,7 @@ The %{name}-libs package contains shared libraries used by %{name}.
 
 %prep
 %setup -q 
+%patch0 -p1
 
 
 %build

--- a/SPECS.p/perl-Tk-TableMatrix/perl-Tk-TableMatrix.spec
+++ b/SPECS.p/perl-Tk-TableMatrix/perl-Tk-TableMatrix.spec
@@ -40,7 +40,7 @@ rm demos/edit_styles.pl.timestamps
 
 
 %build
-%{__perl} Makefile.PL INSTALLDIRS=vendor OPTIMIZE="$RPM_OPT_FLAGS"
+%{__perl} Makefile.PL INSTALLDIRS=vendor OPTIMIZE="$RPM_OPT_FLAGS" X11LIB=%{_libdir} X11INC=%{_includedir}
 make %{?_smp_mflags}
 
 

--- a/SPECS.p/perl-Tk/perl-Tk.spec
+++ b/SPECS.p/perl-Tk/perl-Tk.spec
@@ -82,7 +82,7 @@ chmod -x pod/Popup.pod Tixish/lib/Tk/balArrow.xbm
 %patch3 -p1
 
 %build
-%{__perl} Makefile.PL INSTALLDIRS=vendor X11LIB=%{_libdir} XFT=1
+%{__perl} Makefile.PL INSTALLDIRS=vendor X11LIB=%{_libdir} XFT=1 X11INC=%{_includedir}
 find . -name Makefile | xargs %{__perl} -pi -e 's/^\tLD_RUN_PATH=[^\s]+\s*/\t/'
 make %{?_smp_mflags}
 

--- a/SPECS.p/pure-ftpd/pure-ftpd.spec
+++ b/SPECS.p/pure-ftpd/pure-ftpd.spec
@@ -90,7 +90,7 @@ rm -rf %{buildroot}
 %doc %{_mandir}/man8/*
 %config %{_sysconfdir}/pure-ftpd.conf
 %config %{_sysconfdir}/pure-ftpd/
-%config(noreplace) %{_initrddir}/pure-ftpd/
+%config(noreplace) %{_initrddir}/pure-ftpd
 %config(noreplace) %{_sysconfdir}/pam.d/*
 %{_sbindir}/*
 %{_bindir}/*

--- a/SPECS.p/python/python.spec
+++ b/SPECS.p/python/python.spec
@@ -1558,7 +1558,7 @@ install -d %{buildroot}/usr/lib/python%{pybasever}/site-packages
 %global _pyconfig32_h pyconfig-32.h
 %global _pyconfig64_h pyconfig-64.h
 
-%ifarch %{power64} s390x x86_64 ia64 alpha sparc64 aarch64
+%ifarch %{power64} s390x x86_64 ia64 alpha sparc64 aarch64 mips64el
 %global _pyconfig_h %{_pyconfig64_h}
 %else
 %global _pyconfig_h %{_pyconfig32_h}
@@ -1631,7 +1631,7 @@ done
 # Install a tapset for this libpython into tapsetdir, fixing up the path to the
 # library:
 mkdir -p %{buildroot}%{tapsetdir}
-%ifarch %{power64} s390x x86_64 ia64 alpha sparc64 aarch64
+%ifarch %{power64} s390x x86_64 ia64 alpha sparc64 aarch64 mips64el
 %global libpython_stp_optimized libpython%{pybasever}-64.stp
 %global libpython_stp_debug     libpython%{pybasever}-debug-64.stp
 %else

--- a/SPECS.q/qt4/qt4.spec
+++ b/SPECS.q/qt4/qt4.spec
@@ -1256,7 +1256,11 @@ done
 	-no-rpath \
 	-cups \
 	-stl \
-	-pch \
+%ifarch mips64el
+	-no-pch \
+%else
+	pch \
+%endif
 	-accessibility \
 	-reduce-exports \
 	-reduce-relocations \

--- a/SPECS.r/rpm/rpm.spec
+++ b/SPECS.r/rpm/rpm.spec
@@ -77,6 +77,9 @@ Patch308: rpm-4.11.0.1-setuppy-fixes.patch
 # Temporary Patch to provide support for updates
 Patch400: rpm-4.10.90-rpmlib-filesystem-check.patch
 
+# Mips64el
+Patch500: rpm-4.11.2-mips64el.patch
+
 # Partially GPL/LGPL dual-licensed and some bits with BSD
 # SourceLicense: (GPLv2+ and LGPLv2+ with exceptions) and BSD 
 License: GPLv2+
@@ -284,6 +287,8 @@ packages on a system.
 %patch308 -p1 -b .setuppy-fixes
 
 %patch400 -p1 -b .rpmlib-filesystem-check
+
+%patch500 -p1 -b .mips64el
 
 %patch5 -p1 -b .armhfp
 # this patch cant be applied on softfp builds


### PR DESCRIPTION
openjpeg：
%{_includedir}/openjpeg 是个链接，指向 %{_includedir}/openjpeg-1.4/ 。spec 后面的 / 如果加上，rpmbuild 就提示错误。
ots：
en.xml 重复了，导致安装错误。
python：
mips64el 是 64 位系统，需要进行识别。（之前的修改被覆盖了？）